### PR TITLE
Made sure timestamps are being created with nanoseconds

### DIFF
--- a/Backend/app/Models/PostAction.php
+++ b/Backend/app/Models/PostAction.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Contracts\ActionType;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -16,7 +17,6 @@ class PostAction extends Model
         'post_id',
         'user_ip_address',
         'action_type',
-        'created_at'
     ];
 
     protected $casts = [
@@ -26,5 +26,23 @@ class PostAction extends Model
     public function post(): BelongsTo
     {
         return $this->belongsTo(Post::class);
+    }
+
+    public function asDateTime($value)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        try {
+            return Carbon::createFromFormat('Y-m-d H:i:s.u', $value);
+        } catch (\InvalidArgumentException $e) {
+            return parent::asDateTime($value);
+        }
+    }
+
+    public function getDateFormat()
+    {
+        return 'Y-m-d H:i:s.u';
     }
 }

--- a/Backend/app/Services/PostService.php
+++ b/Backend/app/Services/PostService.php
@@ -71,7 +71,6 @@ class PostService
         $postAction->post_id = $post->id;
         $postAction->user_ip_address = $userIpAddress;
         $postAction->action_type = $actionType;
-        $postAction->created_at = Carbon::now()->format('Y-m-d H:i:s.u'); // TODO: Fix this, database refuses to store microseconds - this is a breaking bug when users interact with posts within the same second
         $postAction->save();
     }
 

--- a/Backend/database/migrations/2023_03_27_151442_override_timestamps_behavior.php
+++ b/Backend/database/migrations/2023_03_27_151442_override_timestamps_behavior.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE post_actions MODIFY created_at TIMESTAMP(6) NOT NULL');
+        DB::statement('ALTER TABLE post_actions MODIFY updated_at TIMESTAMP(6) NULL');
+    }
+
+    public function down(): void
+    {
+
+    }
+};

--- a/Backend/database/seeders/PostActionsSeeder.php
+++ b/Backend/database/seeders/PostActionsSeeder.php
@@ -52,7 +52,7 @@ class PostActionsSeeder extends Seeder
     private function generateRandomActionsInCyclicPattern(string $ipAddress): array
     {
         $actions = [];
-        $maxActions = rand(5, 15);
+        $maxActions = rand(10, 30);
         $timestamp = now();
 
         $cycle = [


### PR DESCRIPTION
Made sure timestamps are being created with nanoseconds
This fixes the bug where we can only have post interactions performed within the same second